### PR TITLE
wrangler.jsonc의 이름 변경

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,7 +4,7 @@
  */
 {
     "$schema": "node_modules/wrangler/config-schema.json",
-    "name": "yellow-salad-d0ea",
+    "name": "hotdeal-alarm",
     "main": "src/index.ts",
     "secrets_store_secrets": [
         {


### PR DESCRIPTION
- 프로젝트 이름을 "yellow-salad-d0ea"에서 "hotdeal-alarm"으로 변경하여 명확성을 높임