### PR TITLE
사용자 키워드 응답 타입 변경 및 불필요한 타입 제거

### DIFF
--- a/src/service/keywordService.ts
+++ b/src/service/keywordService.ts
@@ -1,7 +1,7 @@
 import { getConfig } from '../config';
 import { addMyKeyword, createKeyword, deleteKeyword, getKeywordByTitle, getMyKeywordCount, isKeywordUsed, isMyKeyword, selectUsersKeywords, unlinkUserKeyword } from '../repository/keywordRepository';
 import { UserRepository } from '../repository/userRepository';
-import { KeywordCreateResponse, KeywordDeleteResponse, KeywordResponse, UserKeywordsResponse } from '../types/keyword';
+import { KeywordCreateResponse, KeywordDeleteResponse, KeywordResponse } from '../types/keyword';
 import { KEYWORD_LIMITS, normalizeKeyword, validateKeyword } from '../utils/keyword';
 
 // 키워드 등록 서비스
@@ -94,7 +94,7 @@ export async function unlinkKeyword(keywordId: number, userId: string): Promise<
 }
 
 // 사용자 키워드 목록 조회 서비스
-export async function viewUsersKeywords(userId: string): Promise<UserKeywordsResponse> {
+export async function viewUsersKeywords(userId: string): Promise<KeywordResponse[]> {
     // 환경변수 가져오기
     const config = getConfig();
     const { supabaseUrl, supabaseAnonKey } = config;
@@ -107,10 +107,7 @@ export async function viewUsersKeywords(userId: string): Promise<UserKeywordsRes
         title: keyword.title,
     }));
 
-    return {
-        keywords: keywordResponses,
-        count: keywordResponses.length,
-    };
+    return keywordResponses;
 }
 
 // 키워드 ID로 키워드 정보 조회 서비스

--- a/src/types/keyword.ts
+++ b/src/types/keyword.ts
@@ -44,12 +44,6 @@ export interface KeywordDeleteResponse {
     message: string;
 }
 
-// 사용자 키워드 목록 응답 타입
-export interface UserKeywordsResponse {
-    keywords: KeywordResponse[];
-    count: number;
-}
-
 // 사용자-키워드 연결 테이블 타입
 export interface UserKeyword {
     user_id: string;

--- a/src/view/keywordView.ts
+++ b/src/view/keywordView.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { adminMiddleware, authMiddleware } from '../middleware/authMiddleware';
 import { getKeywordById, registerKeyword, unlinkKeyword, viewUsersKeywords } from '../service/keywordService';
 import { AuthEnv, JwtPayload } from '../types/auth';
-import { KeywordCreateRequest, KeywordCreateResponse, UserKeywordsResponse } from '../types/keyword';
+import { KeywordCreateRequest, KeywordCreateResponse } from '../types/keyword';
 
 export function createKeywordRoutes() {
     const app = new Hono<{ Bindings: AuthEnv; Variables: { user?: JwtPayload } }>();
@@ -44,7 +44,7 @@ export function createKeywordRoutes() {
         try {
             const user = c.get('user')!; // authMiddleware를 통과했으므로 반드시 존재
             // 사용자 키워드 목록 조회 서비스 호출
-            const result: UserKeywordsResponse = await viewUsersKeywords(user.userId);
+            const result = await viewUsersKeywords(user.userId);
 
             return c.json(result, 200);
         } catch (error) {


### PR DESCRIPTION
- 사용자 키워드 목록 조회 서비스의 반환 타입을 UserKeywordsResponse에서 KeywordResponse 배열로 변경하여 간결성을 높임
- UserKeywordsResponse 타입을 제거하여 코드의 가독성을 향상시킴